### PR TITLE
Feature: download texture

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
     "clean": "rm -r built/* & rm -r /dist/* & rm -r /extensions/spector.bundle.js"
   },
   "devDependencies": {
+    "babel": "^6.23.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-es2015": "^6.24.1",
     "css-loader": "^0.28.7",
     "exports-loader": "^0.6.4",
     "http-server": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build:tslint": "tslint -c ./tslint.json -p ./src/tsconfig.json",
     "build": "run-s build:tscss build:tslint build:copy:vendor build:bundle build:copybuild:copy:bundle -l",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "clean": "rm -r built/* & rm -r /dist/* & rm -r /extensions/spector.bundle.js"
+    "clean": "rm -rf built/* & rm -r ./dist/* & rm -r ./extensions/spector.bundle.js"
   },
   "devDependencies": {
     "babel": "^6.23.0",

--- a/src/backend/commands/baseCommand.ts
+++ b/src/backend/commands/baseCommand.ts
@@ -32,8 +32,8 @@ namespace SPECTOR.Commands {
 
             // Includes uniform functions special cases to prevent lots of inheritence.
             const text = (functionInformation.name.indexOf("uniform") === 0) ?
-                this.stringifyUniform(functionInformation.arguments) :
-                this.stringify(functionInformation.arguments, functionInformation.result);
+                this.stringifyUniform(functionInformation.args) :
+                this.stringify(functionInformation.args, functionInformation.result);
 
             const commandCapture = {
                 id: commandCaptureId,
@@ -42,7 +42,7 @@ namespace SPECTOR.Commands {
                 endTime: 0, // Compute at the end
 
                 name: functionInformation.name,
-                commandArguments: functionInformation.arguments,
+                commandArguments: functionInformation.args,
                 result: functionInformation.result,
 
                 stackTrace,

--- a/src/backend/recorders/baseRecorder.ts
+++ b/src/backend/recorders/baseRecorder.ts
@@ -14,7 +14,7 @@ namespace SPECTOR {
     }
 
     export type RecorderConstructor = {
-        new (options: IRecorderOptions, logger: ILogger): IRecorder;
+        new(options: IRecorderOptions, logger: ILogger): IRecorder;
     };
 }
 
@@ -148,12 +148,12 @@ namespace SPECTOR.Recorders {
         }
 
         protected updateWithoutSideEffects(functionInformation: IFunctionInformation): void {
-            if (!functionInformation || functionInformation.arguments.length === 0) {
+            if (!functionInformation || functionInformation.args.length === 0) {
                 return;
             }
 
             this.options.toggleCapture(false);
-            const target = functionInformation.arguments[0];
+            const target = functionInformation.args[0];
             const instance = this.getBoundInstance(target);
             if (!instance) {
                 this.options.toggleCapture(true);
@@ -173,11 +173,11 @@ namespace SPECTOR.Recorders {
         }
 
         protected deleteWithoutSideEffects(functionInformation: IFunctionInformation): void {
-            if (!functionInformation || !functionInformation.arguments || functionInformation.arguments.length < 1) {
+            if (!functionInformation || !functionInformation.args || functionInformation.args.length < 1) {
                 return;
             }
 
-            const instance = functionInformation.arguments[0] as T;
+            const instance = functionInformation.args[0] as T;
             if (!instance) {
                 return;
             }

--- a/src/backend/recorders/bufferRecorder.ts
+++ b/src/backend/recorders/bufferRecorder.ts
@@ -73,21 +73,21 @@ namespace SPECTOR.Recorders {
 
         protected getCustomData(target: string, functionInformation: IFunctionInformation): IBufferRecorderData {
             const length = this.getLength(functionInformation);
-            if (functionInformation.arguments.length >= 4) {
+            if (functionInformation.args.length >= 4) {
                 return {
                     target,
                     length,
-                    usage: functionInformation.arguments[2],
-                    offset: functionInformation.arguments[3],
-                    sourceLength: functionInformation.arguments[1] ? functionInformation.arguments[1].length : -1,
+                    usage: functionInformation.args[2],
+                    offset: functionInformation.args[3],
+                    sourceLength: functionInformation.args[1] ? functionInformation.args[1].length : -1,
                 };
             }
 
-            if (functionInformation.arguments.length === 3) {
+            if (functionInformation.args.length === 3) {
                 return {
                     target,
                     length,
-                    usage: functionInformation.arguments[2],
+                    usage: functionInformation.args[2],
                 };
             }
 
@@ -98,17 +98,17 @@ namespace SPECTOR.Recorders {
             /* tslint:disable */
             let length = -1;
             let offset = 0;
-            if (functionInformation.arguments.length === 5) {
-                length = functionInformation.arguments[4];
-                offset = functionInformation.arguments[3];
+            if (functionInformation.args.length === 5) {
+                length = functionInformation.args[4];
+                offset = functionInformation.args[3];
             }
 
             if (length <= 0) {
-                if (typeof functionInformation.arguments[1] === "number") {
-                    length = functionInformation.arguments[1];
+                if (typeof functionInformation.args[1] === "number") {
+                    length = functionInformation.args[1];
                 }
-                else if (functionInformation.arguments[1]) {
-                    length = functionInformation.arguments[1].byteLength || functionInformation.arguments[1].length || 0;
+                else if (functionInformation.args[1]) {
+                    length = functionInformation.args[1].byteLength || functionInformation.args[1].length || 0;
                 }
                 else {
                     length = 0;

--- a/src/backend/recorders/renderBufferRecorder.ts
+++ b/src/backend/recorders/renderBufferRecorder.ts
@@ -54,12 +54,12 @@ namespace SPECTOR.Recorders {
 
         protected getCustomData(functionInformation: IFunctionInformation, target: string): IRenderBufferRecorderData {
             // renderbufferStorage
-            if (functionInformation.arguments.length === 4) {
+            if (functionInformation.args.length === 4) {
                 return {
                     target,
-                    internalFormat: functionInformation.arguments[1],
-                    width: functionInformation.arguments[2],
-                    height: functionInformation.arguments[3],
+                    internalFormat: functionInformation.args[1],
+                    width: functionInformation.args[2],
+                    height: functionInformation.args[3],
                     length: 0,
                     samples: 0,
                 };
@@ -67,11 +67,11 @@ namespace SPECTOR.Recorders {
 
             return {
                 target,
-                internalFormat: functionInformation.arguments[2],
-                width: functionInformation.arguments[3],
-                height: functionInformation.arguments[4],
+                internalFormat: functionInformation.args[2],
+                width: functionInformation.args[3],
+                height: functionInformation.args[4],
                 length: 0,
-                samples: functionInformation.arguments[1],
+                samples: functionInformation.args[1],
             };
         }
     }

--- a/src/backend/recorders/texture2DRecorder.ts
+++ b/src/backend/recorders/texture2DRecorder.ts
@@ -54,7 +54,7 @@ namespace SPECTOR.Recorders {
         }
 
         protected update(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): number {
-            if (functionInformation.arguments.length >= 2 && functionInformation.arguments[1] !== 0) {
+            if (functionInformation.args.length >= 2 && functionInformation.args[1] !== 0) {
                 return 0;
             }
 
@@ -85,14 +85,14 @@ namespace SPECTOR.Recorders {
 
         private getTexStorage2DCustomData(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): ITextureRecorderData {
             let customData: ITextureRecorderData;
-            if (functionInformation.arguments.length === 5) {
+            if (functionInformation.args.length === 5) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[3],
-                    height: functionInformation.arguments[4],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[3],
+                    height: functionInformation.args[4],
                     length: 0,
                 };
             }
@@ -102,20 +102,20 @@ namespace SPECTOR.Recorders {
         }
 
         private getCompressedTexImage2DCustomData(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): ITextureRecorderData {
-            if (functionInformation.arguments[1] !== 0) {
+            if (functionInformation.args[1] !== 0) {
                 // Only manage main lod... so far.
                 return undefined;
             }
 
             let customData: ITextureRecorderData;
-            if (functionInformation.arguments.length >= 7) {
+            if (functionInformation.args.length >= 7) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[3],
-                    height: functionInformation.arguments[4],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[3],
+                    height: functionInformation.args[4],
                     length: 0,
                 };
             }
@@ -125,35 +125,35 @@ namespace SPECTOR.Recorders {
         }
 
         private getTexImage2DCustomData(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): ITextureRecorderData {
-            if (functionInformation.arguments[1] !== 0) {
+            if (functionInformation.args[1] !== 0) {
                 // Only manage main lod... so far.
                 return undefined;
             }
 
             let customData: ITextureRecorderData;
-            if (functionInformation.arguments.length >= 8) {
+            if (functionInformation.args.length >= 8) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[3],
-                    height: functionInformation.arguments[4],
-                    format: functionInformation.arguments[6],
-                    type: functionInformation.arguments[7],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[3],
+                    height: functionInformation.args[4],
+                    format: functionInformation.args[6],
+                    type: functionInformation.args[7],
                     length: 0,
                 };
             }
-            else if (functionInformation.arguments.length === 6) {
+            else if (functionInformation.args.length === 6) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[5].width,
-                    height: functionInformation.arguments[5].height,
-                    format: functionInformation.arguments[3],
-                    type: functionInformation.arguments[4],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[5].width,
+                    height: functionInformation.args[5].height,
+                    format: functionInformation.args[3],
+                    type: functionInformation.args[4],
                     length: 0,
                 };
             }

--- a/src/backend/recorders/texture3DRecorder.ts
+++ b/src/backend/recorders/texture3DRecorder.ts
@@ -37,7 +37,7 @@ namespace SPECTOR.Recorders {
         }
 
         protected update(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): number {
-            if (functionInformation.arguments.length >= 2 && functionInformation.arguments[1] !== 0) {
+            if (functionInformation.args.length >= 2 && functionInformation.args[1] !== 0) {
                 return 0;
             }
 
@@ -72,15 +72,15 @@ namespace SPECTOR.Recorders {
 
         private getTexStorage3DCustomData(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): ITextureRecorderData {
             let customData: ITextureRecorderData;
-            if (functionInformation.arguments.length === 6) {
+            if (functionInformation.args.length === 6) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[3],
-                    height: functionInformation.arguments[4],
-                    depth: functionInformation.arguments[5],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[3],
+                    height: functionInformation.args[4],
+                    depth: functionInformation.args[5],
                     length: 0,
                 };
             }
@@ -90,21 +90,21 @@ namespace SPECTOR.Recorders {
         }
 
         private getCompressedTexImage3DCustomData(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): ITextureRecorderData {
-            if (functionInformation.arguments[1] !== 0) {
+            if (functionInformation.args[1] !== 0) {
                 // Only manage main lod... so far.
                 return undefined;
             }
 
             let customData: ITextureRecorderData;
-            if (functionInformation.arguments.length >= 8) {
+            if (functionInformation.args.length >= 8) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[3],
-                    height: functionInformation.arguments[4],
-                    depth: functionInformation.arguments[5],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[3],
+                    height: functionInformation.args[4],
+                    depth: functionInformation.args[5],
                     length: 0,
                 };
             }
@@ -114,23 +114,23 @@ namespace SPECTOR.Recorders {
         }
 
         private getTexImage3DCustomData(functionInformation: IFunctionInformation, target: string, instance: WebGLTexture): ITextureRecorderData {
-            if (functionInformation.arguments[1] !== 0) {
+            if (functionInformation.args[1] !== 0) {
                 // Only manage main lod... so far.
                 return undefined;
             }
 
             let customData: ITextureRecorderData;
-            if (functionInformation.arguments.length >= 9) {
+            if (functionInformation.args.length >= 9) {
                 // Custom data required to display the texture.
                 customData = {
                     target,
-                    // level: functionInformation.arguments[1],
-                    internalFormat: functionInformation.arguments[2],
-                    width: functionInformation.arguments[3],
-                    height: functionInformation.arguments[4],
-                    depth: functionInformation.arguments[5],
-                    format: functionInformation.arguments[7],
-                    type: functionInformation.arguments[8],
+                    // level: functionInformation.args[1],
+                    internalFormat: functionInformation.args[2],
+                    width: functionInformation.args[3],
+                    height: functionInformation.args[4],
+                    depth: functionInformation.args[5],
+                    format: functionInformation.args[7],
+                    type: functionInformation.args[8],
                     length: 0,
                 };
             }

--- a/src/backend/spies/commandSpy.ts
+++ b/src/backend/spies/commandSpy.ts
@@ -115,7 +115,7 @@ namespace SPECTOR.Spies {
 
                 const functionInformation = {
                     name: self.spiedCommandName,
-                    arguments,
+                    args: arguments,
                     result,
                     startTime: before,
                     endTime: after,

--- a/src/backend/spies/webGlObjectSpy.ts
+++ b/src/backend/spies/webGlObjectSpy.ts
@@ -16,7 +16,7 @@ namespace SPECTOR {
     }
 
     export type WebGlObjectSpyConstructor = {
-        new (options: IWebGlObjectSpyOptions, logger: ILogger): IWebGlObjectSpy,
+        new(options: IWebGlObjectSpyOptions, logger: ILogger): IWebGlObjectSpy,
     };
 }
 
@@ -42,8 +42,8 @@ namespace SPECTOR.Spies {
             for (const typeName in this.webGlObjects) {
                 if (this.webGlObjects.hasOwnProperty(typeName)) {
                     const webGlObject = this.webGlObjects[typeName];
-                    for (let i = 0; i < functionInformation.arguments.length; i++) {
-                        const arg = functionInformation.arguments[i];
+                    for (let i = 0; i < functionInformation.args.length; i++) {
+                        const arg = functionInformation.args[i];
                         if (webGlObject.tagWebGlObject(arg)) {
                             break;
                         }

--- a/src/backend/types/functionInformation.ts
+++ b/src/backend/types/functionInformation.ts
@@ -7,7 +7,7 @@ namespace SPECTOR {
 
     export interface IFunctionInformation {
         readonly name: string;
-        readonly arguments: IArguments;
+        readonly args: IArguments;
         readonly result: any;
         readonly startTime: number;
         readonly endTime: number;

--- a/src/embeddedFrontend/resultView/JSON/jsonHelpItemComponent.ts
+++ b/src/embeddedFrontend/resultView/JSON/jsonHelpItemComponent.ts
@@ -11,7 +11,7 @@ namespace SPECTOR.EmbeddedFrontend {
             <li><span class="jsonItemComponentKey">${state.key}: </span>
                 <span class="jsonItemComponentValue">${state.value} (<a href="${state.help}" target="_blank" class="jsonSourceItemComponentOpen">Open help page</a>)
                 </span>
-            <li>`;
+            </li>`;
 
             return this.renderElementFromTemplate(htmlString, state, stateId);
         }

--- a/src/embeddedFrontend/resultView/JSON/jsonImageItemComponent.ts
+++ b/src/embeddedFrontend/resultView/JSON/jsonImageItemComponent.ts
@@ -1,8 +1,32 @@
 namespace SPECTOR.EmbeddedFrontend {
-    export class JSONImageItemComponent extends BaseComponent<IJSONItemState> {
-        public render(state: IJSONItemState, stateId: number): Element {
-            const htmlString = this.htmlTemplate`
-            <li class="jsonItemImageHolder"><div class="jsonItemImage"><img src="${state.value}"/><span>${state.key}</span></div></li>`;
+    export interface IJSONImageItemState {
+        key: string;
+        thumbnail: string;
+        realSize: string;
+    }
+
+    export class JSONImageItemComponent extends BaseComponent<IJSONImageItemState> {
+        public render(state: IJSONImageItemState, stateId: number): Element {
+            let htmlString = "";
+            if (state.realSize !== null) {
+                htmlString = this.htmlTemplate`
+                <li class="jsonItemImageHolder">
+                    <div class="jsonItemImage">
+                        <a href="${state.realSize}" download="${state.key}" target="_blank" title="Click image to download" class="jsonSourceItemComponentOpen">
+                            <img src="${state.thumbnail}"/>
+                            <span>${state.key}</span>
+                        </a>
+                    </div>
+                </li>`;
+            } else {
+                htmlString = this.htmlTemplate`
+                <li class="jsonItemImageHolder">
+                    <div class="jsonItemImage">
+                        <img src="${state.thumbnail}"/>
+                        <span>${state.key}</span>
+                    </div>
+                </li>`;
+            }
 
             return this.renderElementFromTemplate(htmlString, state, stateId);
         }

--- a/src/embeddedFrontend/resultView/resultView.ts
+++ b/src/embeddedFrontend/resultView/resultView.ts
@@ -385,10 +385,28 @@ namespace SPECTOR.EmbeddedFrontend {
                 else if (key === "visual") {
                     for (const target in value) {
                         if (value.hasOwnProperty(target) && value[target]) {
-                            this.mvx.addChildState(parentGroupId, {
-                                key: target,
-                                value: value[target],
-                            }, this.jsonImageItemComponent);
+                            try {
+                                value[target].realSize.then((url: any) => {
+                                    this.mvx.addChildState(parentGroupId, {
+                                        key: target,
+                                        thumbnail: value[target].thumbnail,
+                                        realSize: url,
+                                    }, this.jsonImageItemComponent);
+                                });
+                                value[target].realSize.catch(() => {
+                                    this.mvx.addChildState(parentGroupId, {
+                                        key: target,
+                                        thumbnail: value[target].thumbnail,
+                                        realSize: null,
+                                    }, this.jsonImageItemComponent);
+                                });
+                            } catch (e) {
+                                this.mvx.addChildState(parentGroupId, {
+                                    key: target,
+                                    thumbnail: value[target].thumbnail,
+                                    realSize: null,
+                                }, this.jsonImageItemComponent);
+                            }
                         }
                     }
                 }

--- a/src/embeddedFrontend/styles/_resultView.scss
+++ b/src/embeddedFrontend/styles/_resultView.scss
@@ -551,9 +551,10 @@ $commandDetailComponentWidth: 40%;
     width:100%;
 
     img {
-      width: 100%;
+      width: auto;
       display: block;
       margin: auto;
+      min-width: 20px;
       max-width: 256px;
       @include img-checkboard();
     }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,7 +9,7 @@
         "declaration":true,
         "experimentalDecorators": true,
         "module": "none",
-        "target": "es5"
+        "target": "es6"
     },
     "files": [
         "shared/utils/event.ts",

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
         libraryTarget: "umd",
         library: "SPECTOR",
         umdNamedDefine: true
-    },  
+    },
     module: {
         rules: [{
             test: /\.css$/,
@@ -20,7 +20,7 @@ module.exports = {
             use: [ 'exports-loader?Prism' ]
         }, {
             test: /spector.js$/,
-            use: [ 'exports-loader?SPECTOR' ]
+            use: ['exports-loader?SPECTOR', 'babel-loader?presets[]=es2015']
         }]
     }
 }


### PR DESCRIPTION
Hi!
We've been using this tool quite often and it's functionality and speed is outstanding! 
One feature we were missing was the ability to download or view the bound texture at its original resolution.
Currently the render resolution for the bound textures was set to 256x256. 
This PR addes the ability to download the texture at its original resolution.

To avoid stalls (getting an image blob from a 2048x2048 texture can take a while.. ) this is done asyncronously. For that I had to use Promises. These are supported by all major browsers now.
To use promises I had to use es6 features. 
To use es6 features I had to change some code to fix the compilation.

This PR includes:
* Ability to download full resolution textures by clicking on them. Includes fallback to old behaviour if something failed
* upgrade of code to ES6 (1 big change: `arguments` is a reserved keyword)
* Fix for webpack in ES6
* Some small fixes I found while working on this feature.

I've tested this code with most of the provided samples, on Chrome, Firefox and Edge.

Edge currently doesn't support `canvas.toBlob()`, so on Edge the behaviour is the old one. 

Let me know if you require changes!