### PR TITLE
Fixing rebuildProgram parameters description

### DIFF
--- a/documentation/extension.md
+++ b/documentation/extension.md
@@ -112,8 +112,7 @@ If, like BabylonJS, you would like to be able to integrate live shader support e
 
 At any time you are linking a ```ShaderProgram``` in your engine, simply append to it a **rebuild function** allowing your engine to recompile the shader as well as managing all the different states associated to it. The signature of the function should be as follow to be called by Spector:
 ```
-rebuildProgram(program: WebGLProgram, // The Program to rebuild
-            vertexSourceCode: string, // The new vertex shader source
+rebuildProgram(vertexSourceCode: string, // The new vertex shader source
             fragmentSourceCode: string, // The new fragment shader source
             onCompiled: (program: WebGLProgram) => void, // Callback triggered by your engine when the compilation is successful. It needs to send back the new linked program.
             onError: (message: string) => void): void; // Callback triggered by your engine in case of error. It needs to send the WebGL error to allow the editor to display the error in the gutter.


### PR DESCRIPTION
The docs specify a first parameter of `program` for rebuildProgram, but this parameter does not exist in either the Spector.js code nor its matching implementation in BabylonJS: https://github.com/BabylonJS/Babylon.js/blob/0ed4a65d9b5b03fa2c9d7fab651b8f781d9b2e7c/src/Materials/effect.ts#L765