### PR TITLE
Texture Memory calculation: Webgl1 floats and compressed

### DIFF
--- a/src/backend/recorders/baseRecorder.ts
+++ b/src/backend/recorders/baseRecorder.ts
@@ -63,12 +63,6 @@ export abstract class BaseRecorder<T extends WebGLObject> implements IRecorder {
             [WebGlConstants.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC.value]: 4,
             [WebGlConstants.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
             [WebGlConstants.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
-
-            [WebGlConstants.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
-            [WebGlConstants.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
-            [WebGlConstants.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
-            [WebGlConstants.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
-
             [WebGlConstants.COMPRESSED_RGB_S3TC_DXT1_EXT.value]: 0.5,
             [WebGlConstants.COMPRESSED_RGBA_S3TC_DXT3_EXT.value]: 1,
             [WebGlConstants.COMPRESSED_RGBA_S3TC_DXT5_EXT.value]: 1,

--- a/src/backend/recorders/baseRecorder.ts
+++ b/src/backend/recorders/baseRecorder.ts
@@ -63,6 +63,23 @@ export abstract class BaseRecorder<T extends WebGLObject> implements IRecorder {
             [WebGlConstants.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC.value]: 4,
             [WebGlConstants.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
             [WebGlConstants.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
+
+            [WebGlConstants.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
+            [WebGlConstants.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
+            [WebGlConstants.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
+            [WebGlConstants.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2.value]: 4,
+
+            [WebGlConstants.COMPRESSED_RGB_S3TC_DXT1_EXT.value]: 0.5,
+            [WebGlConstants.COMPRESSED_RGBA_S3TC_DXT3_EXT.value]: 1,
+            [WebGlConstants.COMPRESSED_RGBA_S3TC_DXT5_EXT.value]: 1,
+            [WebGlConstants.COMPRESSED_RGB_PVRTC_4BPPV1_IMG.value]: 0.5,
+            [WebGlConstants.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG.value]: 0.5,
+            [WebGlConstants.COMPRESSED_RGB_PVRTC_2BPPV1_IMG.value]: 0.25,
+            [WebGlConstants.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG.value]: 0.25,
+            [WebGlConstants.COMPRESSED_RGB_ETC1_WEBGL.value]: 0.5,
+            [WebGlConstants.COMPRESSED_RGB_ATC_WEBGL.value]: 0.5,
+            [WebGlConstants.COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL.value]: 1,
+            [WebGlConstants.COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL.value]: 1,
         };
     }
 


### PR DESCRIPTION
Fixes #140 

This PR is tested in huge app that has both compressed textures and float textures. Numbers that gave SpectorJS now equal to our internal memory recorder.

PixiJS compressed textures:
https://github.com/pixijs/pixi-compressed-textures/blob/547330b73a1a93b2434e8afe379aa5dcaed40872/src/loaders/DDSLoader.ts#L122
https://github.com/pixijs/pixi-compressed-textures/blob/547330b73a1a93b2434e8afe379aa5dcaed40872/src/loaders/PVRTCLoader.ts#L97

WebGL1 Floats in PixiJS: https://github.com/pixijs/pixi.js/blob/d557af4a1f4324d415c7d414c0a956b8ac23a86a/packages/core/src/textures/TextureSystem.js#L249

Babylon calculation of internal format by type:
https://github.com/BabylonJS/Babylon.js/blob/02bc56455413c63eb0f70926d5936626b5e74929/src/Engines/thinEngine.ts#L4013