### PR TITLE
Add typescript types to release

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   "readme": "documentation/standaloneVersion.md",
   "main": "dist/spector.bundle.js",
   "files": [
-    "dist/spector.bundle.js"
+    "dist/spector.bundle.js",
+    "dist/spector.d.ts",
+    "dist/spector.js.map"
   ],
+  "types": "dist/spector.d.ts",
   "author": "@SpectorJS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds typescript types to the release to make it much easier for people to use Spector.js with typescript

Docs on the subject:
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html