### PR TITLE
Double the preexisting limit to 10k

### DIFF
--- a/documentation/extension.md
+++ b/documentation/extension.md
@@ -83,6 +83,8 @@ The bottom of the menu helps capturing what is happening during the page load on
     <img src="https://spectordoc.babylonjs.com/pictures/extensionResult.png" style="width:512px" width="512px">
 </p>
 
+The current maximum count of captured GL calls is 10000.
+
 Another interesting feature is the ability to drive the extension by code. Once the extension is enabled, from your browser's dev tools, or even your code, you can call the following APIs on spector:
 - ```captureNextFrame(obj: HTMLCanvasElement | RenderingContext)``` : Call to begin a capture of the next frame of a specific canvas or context.
 - ```startCapture(obj: HTMLCanvasElement | RenderingContext, commandCount: number)``` : Start a capture on a specific canvas or context. The capture will stop once it reaches the number of commands specified as a parameter, or after 10 seconds.

--- a/src/spector.ts
+++ b/src/spector.ts
@@ -303,8 +303,8 @@ export class Spector {
             this.capturingContext = contextSpy;
             this.capturingContext.setMarker(this.marker);
 
-            // Limit command count to 5000 record.
-            commandCount = Math.min(commandCount, 5000);
+            // Limit command count to 10000 record.
+            commandCount = Math.min(commandCount, 10000);
             if (commandCount > 0) {
                 this.captureCommands(commandCount);
             }

--- a/src/spector.ts
+++ b/src/spector.ts
@@ -12,6 +12,8 @@ import { Program } from "./backend/webGlObjects/webGlObjects";
 import { CaptureMenu } from "./embeddedFrontend/captureMenu/captureMenu";
 import { ResultView } from "./embeddedFrontend/resultView/resultView";
 
+const CAPTURE_LIMIT = 10000; // Limit command count to 10000 record (to be kept in sync with the documentation)
+
 export interface IAvailableContext {
     readonly canvas: HTMLCanvasElement | OffscreenCanvas;
     readonly contextSpy: ContextSpy;
@@ -303,8 +305,8 @@ export class Spector {
             this.capturingContext = contextSpy;
             this.capturingContext.setMarker(this.marker);
 
-            // Limit command count to 10000 record.
-            commandCount = Math.min(commandCount, 10000);
+            // Limit the shown command count
+            commandCount = Math.min(commandCount, CAPTURE_LIMIT);
             if (commandCount > 0) {
                 this.captureCommands(commandCount);
             }


### PR DESCRIPTION
Sometimes it's useful to capture longer stretches or more verbose sets of calls, work in progress results etc.