### PR TITLE
Add draft extension MultiDrawArray Instanced + BaseInstance + BaseVertex

### DIFF
--- a/src/backend/commands/MultiDrawArraysInstancedBaseInstanceWEBGL.ts
+++ b/src/backend/commands/MultiDrawArraysInstancedBaseInstanceWEBGL.ts
@@ -1,0 +1,22 @@
+import { BaseCommand } from "./baseCommand";
+import { WebGlConstants } from "../types/webglConstants";
+
+export class MultiDrawArraysInstancedBaseInstanceWEBGL extends BaseCommand {
+    public static readonly commandName = "multiDrawArraysInstancedBaseInstanceWEBGL";
+
+    protected get spiedCommandName(): string {
+        return MultiDrawArraysInstancedBaseInstanceWEBGL.commandName;
+    }
+
+    protected stringifyArgs(args: IArguments): string[] {
+        const stringified = [];
+        stringified.push(WebGlConstants.stringifyWebGlConstant(args[0], "multiDrawArraysInstancedBaseInstanceWEBGL"));
+        stringified.push(`drawCount=${args[9]}`);
+        stringified.push(args[2]);
+        stringified.push(args[4]);
+        stringified.push(args[6]);
+        stringified.push(args[8]);
+
+        return stringified;
+    }
+}

--- a/src/backend/commands/MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL.ts
+++ b/src/backend/commands/MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL.ts
@@ -1,0 +1,24 @@
+import { BaseCommand } from "./baseCommand";
+import { WebGlConstants } from "../types/webglConstants";
+
+export class MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL extends BaseCommand {
+    public static readonly commandName = "multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL";
+
+    protected get spiedCommandName(): string {
+        return MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL.commandName;
+    }
+
+    protected stringifyArgs(args: IArguments): string[] {
+        const stringified = [];
+        stringified.push(WebGlConstants.stringifyWebGlConstant(args[0], "multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL"));
+        stringified.push(WebGlConstants.stringifyWebGlConstant(args[3], "multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL"));
+        stringified.push(`drawCount=${args[11]}`);
+        stringified.push(args[2]);
+        stringified.push(args[4]);
+        stringified.push(args[6]);
+        stringified.push(args[8]);
+        stringified.push(args[10]);
+
+        return stringified;
+    }
+}

--- a/src/backend/spies/commandSpy.ts
+++ b/src/backend/spies/commandSpy.ts
@@ -21,6 +21,8 @@ import { GetExtension } from "../commands/getExtension";
 import { GetParameter } from "../commands/getParameter";
 import { GetShaderPrecisionFormat } from "../commands/getShaderPrecisionFormat";
 import { GetTransformFeedbackVarying } from "../commands/getTransformFeedbackVarying";
+import { MultiDrawArraysInstancedBaseInstanceWEBGL } from "../commands/MultiDrawArraysInstancedBaseInstanceWEBGL";
+import { MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL } from "../commands/MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL";
 import { Scissor } from "../commands/scissor";
 import { StencilMask } from "../commands/stencilMask";
 import { StencilMaskSeparate } from "../commands/stencilMaskSeparate";
@@ -144,6 +146,8 @@ export class CommandSpy {
             [GetParameter.commandName]: (options: IContextInformation) => new GetParameter(options),
             [GetShaderPrecisionFormat.commandName]: (options: IContextInformation) => new GetShaderPrecisionFormat(options),
             [GetTransformFeedbackVarying.commandName]: (options: IContextInformation) => new GetTransformFeedbackVarying(options),
+            [MultiDrawArraysInstancedBaseInstanceWEBGL.commandName]: (options: IContextInformation) => new MultiDrawArraysInstancedBaseInstanceWEBGL(options),
+            [MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL.commandName]: (options: IContextInformation) => new MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(options),
             [Scissor.commandName]: (options: IContextInformation) => new Scissor(options),
             [StencilMask.commandName]: (options: IContextInformation) => new StencilMask(options),
             [StencilMaskSeparate.commandName]: (options: IContextInformation) => new StencilMaskSeparate(options),

--- a/src/backend/states/information/extensions.ts
+++ b/src/backend/states/information/extensions.ts
@@ -69,6 +69,7 @@ export class Extensions extends BaseState {
             { name: "WEBGL_compressed_texture_s3tc", description: "" },
                 // { name: "WEBGL_debug_renderer_info", description: "" },
                 // { name: "WEBGL_debug_shaders", description: "" },
+            { name: "WEBGL_multi_draw_instanced_base_vertex_base_instance", description: ""},
             ],
         ];
 

--- a/src/backend/utils/drawCommands.ts
+++ b/src/backend/utils/drawCommands.ts
@@ -6,4 +6,6 @@ export const drawCommands = [
     "drawElementsInstanced",
     "drawElementsInstancedANGLE",
     "drawRangeElements",
+    "multiDrawArraysInstancedBaseInstanceWEBGL",
+    "multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL",
 ];


### PR DESCRIPTION
[WEBGL_multi_draw_instanced_base_vertex_base_instance](https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/) is a promising feature.

I am gonna use it for [madcraft.io](https://madcraft.io) .

Making PR to SpectorJS is also a logical move to push it and convince everyone to finally release it.

![chrome_3bMW5Mbn7Q](https://user-images.githubusercontent.com/695831/168423965-ab0d2f5f-2371-4d1b-aaa5-ffb915b2fd36.png)

