### PR TITLE
Fix MDN link generation for ANGLE_instanced_arrays APIs

### DIFF
--- a/src/embeddedFrontend/resultView/commandList/mdnCommandLinkHelper.ts
+++ b/src/embeddedFrontend/resultView/commandList/mdnCommandLinkHelper.ts
@@ -1,6 +1,7 @@
 export class MDNCommandLinkHelper {
     public static WebGL2RootUrl = "https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/";
     public static WebGLRootUrl = "https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/";
+    public static AngleInstancedArraysExtRootUrl = "https://developer.mozilla.org/en-US/docs/Web/API/ANGLE_instanced_arrays/";
 
     public static WebGL2Functions: { [key: string]: string } = {
         beginQuery: "beginQuery",
@@ -133,6 +134,12 @@ export class MDNCommandLinkHelper {
         vertexAttrib4fv: "vertexAttrib",
     };
 
+    public static AngleInstancedArraysExtFunctions: { [key: string]: string } = {
+        drawArraysInstancedANGLE: "drawArraysInstancedANGLE",
+        drawElementsInstancedANGLE: "drawElementsInstancedANGLE",
+        vertexAttribDivisorANGLE: "vertexAttribDivisorANGLE",
+    };
+
     public static getMDNLink(commandName: string): string {
         const webgl2Name = MDNCommandLinkHelper.WebGL2Functions[commandName];
         if (webgl2Name) {
@@ -141,6 +148,10 @@ export class MDNCommandLinkHelper {
         const webglName = MDNCommandLinkHelper.WebGLFunctions[commandName];
         if (webglName) {
             return MDNCommandLinkHelper.WebGLRootUrl + webglName;
+        }
+        const angleInstancedArraysExtName = MDNCommandLinkHelper.AngleInstancedArraysExtFunctions[commandName];
+        if (angleInstancedArraysExtName) {
+            return MDNCommandLinkHelper.AngleInstancedArraysExtRootUrl + angleInstancedArraysExtName;
         }
         return MDNCommandLinkHelper.WebGLRootUrl + commandName;
     }


### PR DESCRIPTION
It defaulted to the WebGL1 API root previously, resulting in a dead link being generated.

Example: ``drawElementsInstancedANGLE`` call generates link to [this invalid URL](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawElementsInstancedANGLE)

The real link uses the extension name as a prefix: https://developer.mozilla.org/en-US/docs/Web/API/ANGLE_instanced_arrays/drawArraysInstancedANGLE

---

Marked as draft since I'm unsure about what to do next, and I don't know how to test that this actually fixes the issue.

Looks like there are no automated tests? Do I also need to build the bundle? Update the changelog?

Also, what about other extensions, presumably they're also broken? Hmm...