### PR TITLE
Fix readonly spiedScope in timeSpy

### DIFF
--- a/src/backend/spies/timeSpy.ts
+++ b/src/backend/spies/timeSpy.ts
@@ -25,7 +25,7 @@ export class TimeSpy {
     public readonly onFrameEnd: Observable<TimeSpy>;
     public readonly onError: Observable<string>;
 
-    private readonly spiedScope: { [name: string]: any };
+    private spiedScope: { [name: string]: any };
     private readonly lastSixtyFramesDuration: number[];
 
     private lastSixtyFramesCurrentIndex: number;


### PR DESCRIPTION
Fix readonly error.
Sorry about that @sebavan.
Tested it now using `npm run build`.