### PR TITLE
fix capture for float type framebuffers

### DIFF
--- a/src/backend/states/context/visualState.ts
+++ b/src/backend/states/context/visualState.ts
@@ -170,7 +170,7 @@ export class VisualState extends BaseState {
 
             const status = this.context.checkFramebufferStatus(WebGlConstants.FRAMEBUFFER.value);
             if (status === WebGlConstants.FRAMEBUFFER_COMPLETE.value) {
-                this.getCapture(gl, webglConstant.name, x, y, width, height, 0, 0, WebGlConstants.UNSIGNED_BYTE.value);
+                this.getCapture(gl, webglConstant.name, x, y, width, height, 0, 0, componentType);
             }
 
             gl.bindFramebuffer(WebGlConstants.FRAMEBUFFER.value, frameBuffer);


### PR DESCRIPTION
Framebuffers of **float type** generate this warning:

> [.WebGL-xxx] GL_INVALID_OPERATION: Invalid format and type combination.

And therefore generate no preview:
![image](https://github.com/BabylonJS/Spector.js/assets/16117001/995201bb-de5c-4f0b-a485-99c28a207664)
