### PR TITLE
Add option to toggle GLSL beautify

### DIFF
--- a/src/embeddedFrontend/resultView/resultView.ts
+++ b/src/embeddedFrontend/resultView/resultView.ts
@@ -181,6 +181,12 @@ export class ResultView {
                 translatedSourceVertex: sourceCodeState.state.translatedSourceVertex,
             });
         });
+        this.sourceCodeComponent.onBeautifyChanged.add((sourceCodeState) => {
+            const state = this.mvx.getGenericState<ISourceCodeState>(this.sourceCodeComponentStateId);
+            state.beautify = (sourceCodeState.sender as HTMLInputElement).checked;
+            this.mvx.updateState(this.sourceCodeComponentStateId, state);
+        });
+
 
         this.updateViewState();
     }
@@ -286,6 +292,7 @@ export class ResultView {
             fragment,
             translated: false,
             editable: commandState.capture.DrawCall.programStatus.RECOMPILABLE,
+            beautify: true
         }, this.sourceCodeComponent);
 
         this.commandDetailStateId = this.mvx.addChildState(this.contentStateId, null, this.commandDetailComponent);

--- a/src/embeddedFrontend/resultView/sourceCode/sourceCodeComponent.ts
+++ b/src/embeddedFrontend/resultView/sourceCode/sourceCodeComponent.ts
@@ -7,6 +7,7 @@ export interface ISourceCodeState extends ISourceCodeChangeEvent {
     fragment: boolean;
     translated: boolean;
     editable: boolean;
+    beautify: boolean;
 }
 
 // Declare Ace types here.
@@ -41,6 +42,7 @@ export class SourceCodeComponent extends BaseComponent<ISourceCodeState> {
     public onFragmentSourceClicked: IStateEvent<ISourceCodeState>;
     public onSourceCodeCloseClicked: IStateEvent<ISourceCodeState>;
     public onSourceCodeChanged: IStateEvent<ISourceCodeState>;
+    public onBeautifyChanged: IStateEvent<ISourceCodeState>;
 
     private editor: IAceEditor;
 
@@ -52,6 +54,7 @@ export class SourceCodeComponent extends BaseComponent<ISourceCodeState> {
         this.onFragmentSourceClicked = this.createEvent("onFragmentSourceClicked");
         this.onSourceCodeCloseClicked = this.createEvent("onSourceCodeCloseClicked");
         this.onSourceCodeChanged = this.createEvent("onSourceCodeChanged");
+        this.onBeautifyChanged = this.createEvent("onBeautifyChanged");
     }
 
     public showError(errorMessage: string) {
@@ -82,14 +85,16 @@ export class SourceCodeComponent extends BaseComponent<ISourceCodeState> {
 
     public render(state: ISourceCodeState, stateId: number): Element {
         const source = state.fragment ? state.sourceFragment : state.sourceVertex;
-        let formattedShader: string;
+        let originalShader: string;
         // tslint:disable-next-line:prefer-conditional-expression
         if (state.translated) {
-            formattedShader = state.fragment ? state.translatedSourceFragment : state.translatedSourceVertex;
+            originalShader = state.fragment ? state.translatedSourceFragment : state.translatedSourceVertex;
         }
         else {
-            formattedShader = source ? this._indentIfdef(this._beautify(source)) : "";
+            originalShader = source ?? "";
         }
+
+        const displayedShader = state.beautify ? this._indentIfdef(this._beautify(originalShader)) : originalShader;
 
         const htmlString = this.htmlTemplate`
         <div class="sourceCodeComponentContainer">
@@ -103,8 +108,13 @@ export class SourceCodeComponent extends BaseComponent<ISourceCodeState> {
                 </ul>
             </div>
             $${
-            this.htmlTemplate`<div class="sourceCodeComponent">${formattedShader}</div>`
+            this.htmlTemplate`<div class="sourceCodeComponent">${displayedShader}</div>`
             }
+            <div class="sourceCodeMenuComponentFooter">
+                <p>
+                    <label><input type="checkbox" commandName="onBeautifyChanged" ${state.beautify ? "checked" : ""} /> Beautify</label>
+                </p>
+            </div>
         </div>`;
 
         const element = this.renderElementFromTemplate(htmlString.replace(/<br>/g, "\n"), state, stateId);

--- a/src/embeddedFrontend/styles/resultView.scss
+++ b/src/embeddedFrontend/styles/resultView.scss
@@ -620,7 +620,16 @@ $commandDetailComponentWidth: 40%;
   position: absolute;
   left: 0;
   top: 0;
+  bottom: 48px;
   right: $commandDetailComponentWidth;
+}
+
+.sourceCodeMenuComponentFooter {
+  position: absolute;
+  left: 0;
+  right: $commandDetailComponentWidth;
+  bottom: 0;
+  padding: 0 15px;
 }
 
 .sourceCodeMenuComponent {
@@ -759,7 +768,7 @@ $commandDetailComponentWidth: 40%;
   position:absolute; 
   top: $menuHeight + $border;
   left: 0;  
-  bottom: 0;
+  bottom: 48px;
   right: $commandDetailComponentWidth;
   background: $background;
   z-index: 9000;


### PR DESCRIPTION
Split from https://github.com/BabylonJS/Spector.js/pull/272#issuecomment-1650056238

(I'll rename and adapt issue #269 once this is merged, so #269 focuses on the breakage of the preprocessor reformatting during beautification)