### PR TITLE
BaseVertexBaseInstance without multidraw

### DIFF
--- a/src/backend/commands/drawArraysInstancedBaseInstanceWEBGL.ts
+++ b/src/backend/commands/drawArraysInstancedBaseInstanceWEBGL.ts
@@ -1,0 +1,21 @@
+import { BaseCommand } from "./baseCommand";
+import { WebGlConstants } from "../types/webglConstants";
+
+export class DrawArraysInstancedBaseInstanceWEBGL extends BaseCommand {
+    public static readonly commandName = "drawArraysInstancedBaseInstanceWEBGL";
+
+    protected get spiedCommandName(): string {
+        return DrawArraysInstancedBaseInstanceWEBGL.commandName;
+    }
+
+    protected stringifyArgs(args: IArguments): string[] {
+        const stringified = [];
+        stringified.push(WebGlConstants.stringifyWebGlConstant(args[0], "drawArraysInstanced"));
+        stringified.push(args[1]);
+        stringified.push(args[2]);
+        stringified.push(args[3]);
+        stringified.push(`baseInstance = ${args[4]}`);
+
+        return stringified;
+    }
+}

--- a/src/backend/commands/drawElementsInstancedBaseVertexBaseInstanceWEBGL.ts
+++ b/src/backend/commands/drawElementsInstancedBaseVertexBaseInstanceWEBGL.ts
@@ -1,0 +1,24 @@
+import { BaseCommand } from "./baseCommand";
+import { WebGlConstants } from "../types/webglConstants";
+
+export class DrawElementsInstancedBaseVertexBaseInstanceWEBGL extends BaseCommand {
+    public static readonly commandName = "drawElementsInstancedBaseVertexBaseInstanceWEBGL";
+
+    protected get spiedCommandName(): string {
+        return DrawElementsInstancedBaseVertexBaseInstanceWEBGL .commandName;
+    }
+
+    protected stringifyArgs(args: IArguments): string[] {
+        const stringified = [];
+        stringified.push(WebGlConstants.stringifyWebGlConstant(args[0], "drawElementsInstanced"));
+        stringified.push(args[1]);
+        stringified.push(WebGlConstants.stringifyWebGlConstant(args[2], "drawElementsInstanced"));
+        stringified.push(args[3]);
+        stringified.push(args[4]);
+
+        stringified.push(`baseVertex = ${args[5]}`);
+        stringified.push(`baseInstance = ${args[6]}`);
+
+        return stringified;
+    }
+}

--- a/src/backend/spies/commandSpy.ts
+++ b/src/backend/spies/commandSpy.ts
@@ -29,6 +29,8 @@ import { MultiDrawArraysWEBGL } from "../commands/MultiDrawArraysWEBGL";
 import { MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL } from "../commands/MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL";
 import { MultiDrawElementsInstancedWEBGL } from "../commands/MultiDrawElementsInstancedWEBGL";
 import { MultiDrawElementsWEBGL } from "../commands/MultiDrawElementsWEBGL";
+import { DrawArraysInstancedBaseInstanceWEBGL } from "../commands/drawArraysInstancedBaseInstanceWEBGL";
+import { DrawElementsInstancedBaseVertexBaseInstanceWEBGL } from "../commands/drawElementsInstancedBaseVertexBaseInstanceWEBGL";
 
 import { Scissor } from "../commands/scissor";
 import { StencilMask } from "../commands/stencilMask";
@@ -161,6 +163,8 @@ export class CommandSpy {
             [MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL.commandName]: (options: IContextInformation) => new MultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(options),
             [MultiDrawElementsInstancedWEBGL.commandName]: (options: IContextInformation) => new MultiDrawElementsInstancedWEBGL(options),
             [MultiDrawElementsWEBGL.commandName]: (options: IContextInformation) => new MultiDrawElementsWEBGL(options),
+            [DrawArraysInstancedBaseInstanceWEBGL.commandName]: (options: IContextInformation) => new DrawArraysInstancedBaseInstanceWEBGL(options),
+            [DrawElementsInstancedBaseVertexBaseInstanceWEBGL.commandName]: (options: IContextInformation) => new DrawElementsInstancedBaseVertexBaseInstanceWEBGL(options),
             [Scissor.commandName]: (options: IContextInformation) => new Scissor(options),
             [StencilMask.commandName]: (options: IContextInformation) => new StencilMask(options),
             [StencilMaskSeparate.commandName]: (options: IContextInformation) => new StencilMaskSeparate(options),

--- a/src/backend/states/information/extensions.ts
+++ b/src/backend/states/information/extensions.ts
@@ -71,6 +71,7 @@ export class Extensions extends BaseState {
                 // { name: "WEBGL_debug_shaders", description: "" },
             { name: "WEBGL_multi_draw", description: ""},
             { name: "WEBGL_multi_draw_instanced_base_vertex_base_instance", description: ""},
+            { name: "WEBGL_draw_instanced_base_vertex_base_instance", description: ""},
             ],
         ];
 

--- a/src/backend/utils/drawCommands.ts
+++ b/src/backend/utils/drawCommands.ts
@@ -12,4 +12,6 @@ export const drawCommands = [
     "multiDrawElementsInstancedWEBGL",
     "multiDrawArraysInstancedBaseInstanceWEBGL",
     "multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL",
+    "drawArraysInstancedBaseInstanceWEBGL",
+    "drawElementsInstancedBaseVertexBaseInstanceWEBGL"
 ];


### PR DESCRIPTION
Here is another draft extension, like in my previous PR's. I don't know why Chrome didnt enable it yet :(

![image](https://github.com/BabylonJS/Spector.js/assets/695831/97799394-5e17-46c7-a91e-139458687922)
