### PR TITLE
Fix framebuffer texture capture with texStorage2D bug

### DIFF
--- a/src/backend/states/context/visualState.ts
+++ b/src/backend/states/context/visualState.ts
@@ -207,7 +207,9 @@ export class VisualState extends BaseState {
             const info = storage.__SPECTOR_Object_CustomData as ITextureRecorderData;
             width = info.width;
             height = info.height;
-            textureType = info.type;
+            if (info.type !== undefined) {
+                textureType = info.type;
+            }
             knownAsTextureArray = info.target === WebGlConstants.TEXTURE_2D_ARRAY.name;
             if (!ReadPixelsHelper.isSupportedCombination(info.type, info.format, info.internalFormat)) {
                 return;


### PR DESCRIPTION
## Bug
Test demo: https://06wj.github.io/test/spectorJSTest/
The picture below is the capture result.The framebuffer display a blank picture.
<img width="858" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/550fb058-9e46-432b-84ff-652f5ca11021">


## Solution
When using texStorage2D, there is no type value in the texture customData.
<img width="769" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/11a9737f-ef92-4e4d-9635-a566b5d3e0f6">

Because there is no type value in customData, textureType will be set to null, causing an error when readPixels is called, leading to a capture failure.
<img width="949" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/f59a3d39-b68e-4fa9-8ea7-561455ddf80a">

So a change has been made here. When there is no type, the framebuffer's attachmentComponentType is still used.
The picture below is the fixed capture result.
<img width="784" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/ec025baf-0e68-4490-a54d-c2f3c0280f55">
