### PR TITLE
Add option to toggle GLSL preprocess

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "build": "run-s build:tslint build:bundle build:copybuild:copy:bundle build:concatBundleFunc -n",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "@shaderfrog/glsl-parser": "^2.0.1"
+  },
   "devDependencies": {
     "@types/webxr": "^0.5.1",
     "concat-cli": "^4.0.0",

--- a/src/embeddedFrontend/resultView/resultView.ts
+++ b/src/embeddedFrontend/resultView/resultView.ts
@@ -186,6 +186,11 @@ export class ResultView {
             state.beautify = (sourceCodeState.sender as HTMLInputElement).checked;
             this.mvx.updateState(this.sourceCodeComponentStateId, state);
         });
+        this.sourceCodeComponent.onPreprocessChanged.add((sourceCodeState) => {
+            const state = this.mvx.getGenericState<ISourceCodeState>(this.sourceCodeComponentStateId);
+            state.preprocessed = (sourceCodeState.sender as HTMLInputElement).checked;
+            this.mvx.updateState(this.sourceCodeComponentStateId, state);
+        });
 
 
         this.updateViewState();


### PR DESCRIPTION
Added a switch for shader preprocess, making it easier to understand the shader and get rid of any unnecessary distractions.

* Test demo: https://hilo3d.js.org/examples/geometry_box.html
* The builded extensions for test
[extensions.zip](https://github.com/BabylonJS/Spector.js/files/13790244/extensions.zip)
* preprocess off:
    <img width="738" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/831a5c49-4f86-4794-926d-30ed76a6ae04">

* preprocess on:
    <img width="726" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/4ac2dfad-1bc9-4744-9a96-944fdac2a7b5">


