### PR TITLE
Fix the display issue when the width and height of the framebuffer are decimals

### DIFF
--- a/src/backend/states/context/visualState.ts
+++ b/src/backend/states/context/visualState.ts
@@ -241,6 +241,9 @@ export class VisualState extends BaseState {
 
     protected getCapture(gl: WebGLRenderingContext, name: string, x: number, y: number, width: number, height: number,
         textureCubeMapFace: number, textureLayer: number, type: number) {
+        width = Math.floor(width);
+        height = Math.floor(height);
+
         const attachmentVisualState = {
             attachmentName: name,
             src: null as string,
@@ -256,7 +259,7 @@ export class VisualState extends BaseState {
                     // Copy the pixels to a working 2D canvas same size.
                     this.workingCanvas.width = width;
                     this.workingCanvas.height = height;
-                    const imageData = this.workingContext2D.createImageData(Math.ceil(width), Math.ceil(height));
+                    const imageData = this.workingContext2D.createImageData(width, height);
                     imageData.data.set(pixels);
                     this.workingContext2D.putImageData(imageData, 0, 0);
 

--- a/src/backend/states/drawCalls/drawCallTextureInputState.ts
+++ b/src/backend/states/drawCalls/drawCallTextureInputState.ts
@@ -142,6 +142,9 @@ export class DrawCallTextureInputState {
     }
 
     protected getCapture(gl: WebGLRenderingContext, x: number, y: number, width: number, height: number, type: number, pixelated: boolean): string {
+        width = Math.floor(width);
+        height = Math.floor(height);
+
         try {
             // Check FBO status.
             const status = this.context.checkFramebufferStatus(WebGlConstants.FRAMEBUFFER.value);


### PR DESCRIPTION
Test demo: https://06wj.github.io/test/framebufferTest/index.html
The width of the framebuffer in the demo is 1023.4004.

### Before
There are two display issues，
1. The display of the framebuffer is wrong, it looks split and tilted
    <img width="898" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/bb87e900-5ad9-4f6a-92dc-e042d8b39919">
2.  The texture read from the framebuffer in the material is not displayed
     <img width="1386" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/12de28ca-150a-4b03-8ec4-1dbe1e2c45e1">

### After  fix
1. <img width="900" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/b92d0968-9969-4dca-b8fa-83c8b277a560">
2.  <img width="1394" alt="image" src="https://github.com/BabylonJS/Spector.js/assets/800043/785ef3c7-fd4a-42ac-a82f-a4fd0f7c98d1">

### The fixed extension
[extensions 2.zip](https://github.com/BabylonJS/Spector.js/files/15097701/extensions.2.zip)


