### PR TITLE
fix: correct error in buffer length calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@shaderfrog/glsl-parser": "^2.0.1"
+    "@shaderfrog/glsl-parser": "^5.0.0"
   },
   "devDependencies": {
     "@types/webxr": "^0.5.1",

--- a/src/backend/recorders/bufferRecorder.ts
+++ b/src/backend/recorders/bufferRecorder.ts
@@ -101,25 +101,29 @@ export class BufferRecorder extends BaseRecorder<WebGLBuffer> {
 
     protected getLength(functionInformation: IFunctionInformation): number {
         /* tslint:disable */
-        let length = -1;
-        let offset = 0;
-        if (functionInformation.arguments.length === 5) {
-            length = functionInformation.arguments[4];
-            offset = functionInformation.arguments[3];
+        const sizeOrData = functionInformation.arguments[1];
+        const offset = functionInformation.arguments[3];
+        const length = functionInformation.arguments[4];
+
+        // bufferData(target, size, usage)
+        if (typeof sizeOrData === 'number') {
+            return sizeOrData;
         }
 
-        if (length <= 0) {
-            if (typeof functionInformation.arguments[1] === "number") {
-                length = functionInformation.arguments[1];
-            }
-            else if (functionInformation.arguments[1]) {
-                length = functionInformation.arguments[1].byteLength || functionInformation.arguments[1].length || 0;
-            }
-            else {
-                length = 0;
-            }
+        // bufferData(target, srcData, usage, srcOffset, length)
+        if (typeof length === 'number' && length > 0) {
+            return length;
         }
 
-        return length - offset;
+        const dataLength = sizeOrData.byteLength || sizeOrData.length || 0;
+
+        // bufferData(target, srcData, usage, srcOffset)
+        if (typeof offset === 'number' && offset > 0) {
+            return dataLength - offset;
+        }
+        // bufferData(target, srcData, usage)
+        else {
+            return dataLength;
+        }
     }
 }


### PR DESCRIPTION
### Description

This pull request addresses an issue with the buffer length calculation. The fix ensures that the buffer length is calculated correctly according to the WebGL2RenderingContext API specifications.

### Changes

- Corrected the buffer length calculation logic to align with the expected behavior.
- Updated the glsl-parser to the latest version, fixing several preprocessing bugs. e.g.  [Fixing preprocessor generate bug](https://github.com/ShaderFrog/glsl-parser/pull/20)

### Testing

A test demo has been created to verify the correctness of the buffer length calculation: [Buffer Data Test](https://06wj.github.io/test/bufferDataTest/index.html)

### Buffer Length Comparison in [Buffer Data Test](https://06wj.github.io/test/bufferDataTest/index.html)

| bufferData                                  | Description                                   | Correct Length | Spector.js Length |
|---------------------------------------------|-----------------------------------------------|------|-----|
| `ARRAY_BUFFER, [..(8)..], STATIC_DRAW`      | Buffer with 8 float32 elements, static draw   | 32   | 32  |
| `ARRAY_BUFFER, [..(40)..], STATIC_DRAW, 8, 0` | Buffer with 40 elements, static draw, offset 8, size 0 | 32   | 32  |
| `ARRAY_BUFFER, [..(40)..], STATIC_DRAW, 8`  | Buffer with 40 elements, static draw, offset 8 | 32   | 40  |
| `ARRAY_BUFFER, [..(48)..], STATIC_DRAW, 8, 32` | Buffer with 48 elements, static draw, offset 8, size 32 | 32   | 24  |
| `ARRAY_BUFFER, 32, STATIC_DRAW`             | Buffer with size 32, static draw              | 32   | 32  |

### Reference

The bufferData API documentation can be found here: [WebGL2RenderingContext.bufferData](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/bufferData)

### The builded extension for test
You can use the following built extension to test the changes: [extensions.zip](https://github.com/user-attachments/files/18385570/extensions.zip). All test results are correct with this extension.

The new logic handles all cases of the bufferData function:
* `bufferData(target, size, usage)`: Returns `size`.
* `bufferData(target, srcData, usage, srcOffset, length)`: Returns `length` if `length` is greater than 0.(otherwise proceeds to the next logic)
* `bufferData(target, srcData, usage, srcOffset)`: Returns `dataLength - offset` if `offset` is greater than 0.(otherwise proceeds to the next logic)
* `bufferData(target, srcData, usage)`: Returns `dataLength`.

