### PR TITLE
Fix spyContext wrongly hooking non-GL functions

### DIFF
--- a/src/backend/spies/contextSpy.ts
+++ b/src/backend/spies/contextSpy.ts
@@ -229,7 +229,7 @@ export class ContextSpy {
             }
 
             try {
-                const isFunction = typeof bindingContext[member] !== "number";
+                const isFunction = typeof bindingContext[member] === "function";
                 if (isFunction) {
                     this.spyFunction(member, bindingContext);
                 }


### PR DESCRIPTION
When using WebGL via emscripten, extensions might be set on the GL context:

```js
var _glClipControlEXT = (origin, depth) => {
  GLctx.extClipControl["clipControlEXT"](origin, depth);
};
```

Unfortunately that doesn't play nicely with Spector that will wrongly try to hook `extClipControl` here.